### PR TITLE
descriptive 404 in .bin/serve

### DIFF
--- a/.bin/serve
+++ b/.bin/serve
@@ -58,7 +58,17 @@ Phant.HttpServer.use(function(req, res) {
     return;
   }
 
-  var body = 'phant is ready and listening for input.\n';
+  if(req.url.match(/^\/streams/)) {
+    var body = '404 Not Found\n\n' + 
+      'phant-manager-http is needed for /streams URLs\n' +
+      'see README for install instructions: \n' +
+      'https://github.com/sparkfun/phant-manager-http\n';
+
+  } else {
+    var body = '404 Not Found\n\n' + 
+      'Expecting URLs starting with /input or /output';
+  }
+
 
   res.writeHead(404, {
     'Content-Type': 'text/plain',


### PR DESCRIPTION
The current 404 error message text in .bin/serve
makes it look like you're doing something
that should work. This update gives
a more descriptive message, including
a link to phant-manger-http if they're
attempting to access /streams
