### PR TITLE
Ends stream when there are no more values greater than (or equal to) …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node
+
+MAINTAINER idcrook@users.noreply.github.com
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package.json /usr/src/app/
+RUN npm install
+
+# Bundle app source
+COPY . /usr/src/app
+
+# EXPOSE 8888
+# EXPOSE 8889
+#    http_port = process.env.PHANT_PORT || 8080,
+#    telnet_port = process.env.PHANT_TELNET_PORT || 8081;
+# VOLUME /phant_streams
+
+# ENTRYPOINT ["phant"]
+# CMD ["/usr/local/bin/phant"]
+CMD ["npm", "start"]
+
+# docker built -t <image_name> .
+# docker run -d -p 8888:8888 -p 8889:8889 -e PHANT_PORT='8888' -e PHANT_TELNET_PORT='8889' -v ./phant_streams/:/usr/src/app/phant_streams/ dpcrook/phant

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ Type 'help' for a list of available commands
 phant>
 ```
 
+#### Local using Docker / docker-compose
+
+```bash
+git clone https://github.com/idcrook/phant.git
+cd phant
+mkdir ./phant_streams
+docker-compose build
+docker-compose up     # or as service: 'docker-compose start'
+open http://localhost:8888
+```
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+phant_server:
+  restart: always
+  build: .
+  container_name: phant
+  working_dir: /usr/src/app  
+  command: ./.bin/serve
+  ports:
+    - "8888:8888"
+    - "8889:8889"
+  environment:
+    - PHANT_PORT=8888
+    - PHANT_TELNET_PORT=8889
+  volumes:
+    - ./phant_streams:/usr/src/app/phant_streams/
+

--- a/lib/filter_stream.js
+++ b/lib/filter_stream.js
@@ -141,12 +141,15 @@ app.numeric = function(operator, obj, encoding, callback) {
     case 'gt':
       if (field > operand) {
         this.push(obj);
-      } else if (this.field === 'timestamp') this.end()
+      } else if (this.field === 'timestamp') {
+        this.end();
+      }
       break;
     case 'gte':
       if (field >= operand) {
         this.push(obj);
-      } else if (this.field === 'timestamp') this.end();
+      } else if (this.field === 'timestamp') {
+        this.end();
       break;
     case 'lt':
       if (field < operand) {

--- a/lib/filter_stream.js
+++ b/lib/filter_stream.js
@@ -141,12 +141,12 @@ app.numeric = function(operator, obj, encoding, callback) {
     case 'gt':
       if (field > operand) {
         this.push(obj);
-      }
+      } else if (this.field === 'timestamp') this.end()
       break;
     case 'gte':
       if (field >= operand) {
         this.push(obj);
-      }
+      } else if (this.field === 'timestamp') this.end();
       break;
     case 'lt':
       if (field < operand) {

--- a/lib/filter_stream.js
+++ b/lib/filter_stream.js
@@ -150,6 +150,7 @@ app.numeric = function(operator, obj, encoding, callback) {
         this.push(obj);
       } else if (this.field === 'timestamp') {
         this.end();
+      }
       break;
     case 'lt':
       if (field < operand) {

--- a/lib/http_output.js
+++ b/lib/http_output.js
@@ -320,7 +320,7 @@ app.preventExcessChunking = function(data, stream, res) {
   });
 
   data.pipe(stream);
-}
+};
 
 app.addFilters = function(query, stream) {
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -170,9 +170,9 @@ app.fields = function(id, data, callback) {
     // make sure all keys are valid
     for (var key in data) {
 
-      if (!data.hasOwnProperty(key)) {
-        continue;
-      }
+//       if (!data.hasOwnProperty(key)) {
+//         continue;
+//       }
 
       if (data[key] instanceof Array) {
         return callback('two values were sent for the same field: ' + key, false);
@@ -191,8 +191,7 @@ app.fields = function(id, data, callback) {
 
     // make sure all fields exist in data
     for (var i = 0; i < stream.fields.length; i++) {
-
-      if (!data.hasOwnProperty(stream.fields[i])) {
+      if ( ! (stream.fields[i] in data) ) {
 
         err = stream.fields[i] + " missing from sent data. \n\n";
         err += 'expecting: ' + expecting.join(', ');


### PR DESCRIPTION
…the filtered timestamp


This patch makes querying by timestamp ~10x faster for me. Assuming that streams are always in chronological order, I don't think this will have any negative side effects.