### PR TITLE
Update project status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # phant [![Build Status](https://secure.travis-ci.org/sparkfun/phant.svg?branch=master)](http://travis-ci.org/sparkfun/phant)
 
+> **UPDATE 2017-04-25**
+>
+> This project is no longer actively maintained. Maintenance of the freely
+> available service at data.sparkfun.com has a very low priority and has no
+> service guarantees, please use at your own risk.
+
 phant is a modular logging tool developed by [SparkFun Electronics](https://sparkfun.com) for collecting data from
 the [Internet of Things](http://en.wikipedia.org/wiki/Internet_of_Things).  phant is the open source software that powers
 [data.sparkfun.com](http://data.sparkfun.com).


### PR DESCRIPTION
The ambiguity of the status of this project has been touched upon in
many recent issues. This update removes ambiguity about this service and
this software. The outcome here is that phant will officially be
de-prioritized; however, this signals to the community surrounding phant
that new maintainership would be welcome.

An alternative to this pull request may be to open up commit access to
members of the dev community. @stoto and @adewinter have done
some stuff recently...

Fixes: #222, #221, #219, #208, #188, #187, #179